### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,8 +9,8 @@
     "data operations"
   ],
   "description": "Creates images project from video project",
-  "docker_image": "supervisely/data-operations:6.73.486",
-  "min_instance_version": "6.15.35",
+  "docker_image": "supervisely/data-operations:6.73.564",
+  "instance_version": "6.15.60",
   "entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",
   "port": 8000,
   "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
     "data operations"
   ],
   "description": "Creates images project from video project",
-  "docker_image": "supervisely/data-operations:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",
   "port": 8000,

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.486
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
